### PR TITLE
Fix Magepack commands

### DIFF
--- a/magepack/bin/bundle.sh
+++ b/magepack/bin/bundle.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/usr/bin/magepack bundle
+/usr/local/bin/magepack bundle

--- a/magepack/bin/generate.sh
+++ b/magepack/bin/generate.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/usr/bin/magepack generate "$@"
+/usr/local/bin/magepack generate "$@"


### PR DESCRIPTION
I could swear I sent this PR previously already, but obviously, I did not.

In the latest images, Magepack is available under a different path:

    $ which magepack
    /usr/local/bin/magepack

Hence, this PR fixes the Magepack commands.