### PR TITLE
wardenenv/images#719 - Add PHP-SPX image build

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -6,6 +6,8 @@ ENV NGINX_UPSTREAM_HOST           php-fpm
 ENV NGINX_UPSTREAM_PORT           9000
 ENV NGINX_UPSTREAM_DEBUG_HOST     php-debug
 ENV NGINX_UPSTREAM_DEBUG_PORT     9000
+ENV NGINX_UPSTREAM_SPX_HOST       php-spx
+ENV NGINX_UPSTREAM_SPX_PORT       9000
 ENV NGINX_UPSTREAM_BLACKFIRE_HOST php-blackfire
 ENV NGINX_UPSTREAM_BLACKFIRE_PORT 9000
 ENV NGINX_ROOT                    /var/www/html
@@ -20,6 +22,7 @@ COPY etc/nginx/available.d/*.conf /etc/nginx/available.d/
 CMD envsubst '${NGINX_UPSTREAM_HOST} ${NGINX_UPSTREAM_PORT} \
               ${NGINX_UPSTREAM_BLACKFIRE_HOST} ${NGINX_UPSTREAM_BLACKFIRE_PORT} \
               ${NGINX_UPSTREAM_DEBUG_HOST} ${NGINX_UPSTREAM_DEBUG_PORT} \
+              ${NGINX_UPSTREAM_SPX_HOST} ${NGINX_UPSTREAM_SPX_PORT} \
               ${NGINX_ROOT} ${NGINX_PUBLIC} ${NGINX_TEMPLATE}' \
         < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf \
     && envsubst '${XDEBUG_CONNECT_BACK_HOST}' \

--- a/nginx/etc/nginx/conf.d/default.conf
+++ b/nginx/etc/nginx/conf.d/default.conf
@@ -3,8 +3,6 @@ resolver 127.0.0.11;
 
 # Select upstream backend to use based on presense of Xdebug cookies and Blackfire headers
 map "$http_X_BLACKFIRE_QUERY:$cookie_XDEBUG_SESSION$cookie_XDEBUG_PROFILE$cookie_XDEBUG_TRACE$arg_XDEBUG_SESSION$arg_XDEBUG_SESSION_START:$cookie_SPX_ENABLED$cookie_SPX_KEY$arg_SPX_ENABLED$arg_SPX_KEY$arg_SPX_UI_URI" $fastcgi_backend {
-    volatile;
-
     # Nothing for debug and nothing for blackfire means its a pure request
     "::" ${NGINX_UPSTREAM_HOST}:${NGINX_UPSTREAM_PORT};
 

--- a/nginx/etc/nginx/conf.d/default.conf
+++ b/nginx/etc/nginx/conf.d/default.conf
@@ -2,12 +2,17 @@
 resolver 127.0.0.11;
 
 # Select upstream backend to use based on presense of Xdebug cookies and Blackfire headers
-map "$http_X_BLACKFIRE_QUERY:$cookie_XDEBUG_SESSION$cookie_XDEBUG_PROFILE$cookie_XDEBUG_TRACE$arg_XDEBUG_SESSION$arg_XDEBUG_SESSION_START" $fastcgi_backend {
+map "$http_X_BLACKFIRE_QUERY:$cookie_XDEBUG_SESSION$cookie_XDEBUG_PROFILE$cookie_XDEBUG_TRACE$arg_XDEBUG_SESSION$arg_XDEBUG_SESSION_START:$cookie_SPX_ENABLED$cookie_SPX_KEY$arg_SPX_ENABLED$arg_SPX_KEY$arg_SPX_UI_URI" $fastcgi_backend {
+    volatile;
+
     # Nothing for debug and nothing for blackfire means its a pure request
-    ":" ${NGINX_UPSTREAM_HOST}:${NGINX_UPSTREAM_PORT};
+    "::" ${NGINX_UPSTREAM_HOST}:${NGINX_UPSTREAM_PORT};
 
     # Use blackfire if the blackfire query is specified AND no debug cookie is set
-    "~:$" ${NGINX_UPSTREAM_BLACKFIRE_HOST}:${NGINX_UPSTREAM_BLACKFIRE_PORT};
+    "~::$" ${NGINX_UPSTREAM_BLACKFIRE_HOST}:${NGINX_UPSTREAM_BLACKFIRE_PORT};
+
+    # Use SPX if the SPX cookie is specified AND no xdebug cookie is set
+    "~::.+" ${NGINX_UPSTREAM_SPX_HOST}:${NGINX_UPSTREAM_SPX_PORT};
 
     # In all other cases, a debug cookie will be present; use debug container
     default ${NGINX_UPSTREAM_DEBUG_HOST}:${NGINX_UPSTREAM_DEBUG_PORT};

--- a/php-fpm/spx/Dockerfile
+++ b/php-fpm/spx/Dockerfile
@@ -1,0 +1,25 @@
+ARG ENV_SOURCE_IMAGE
+ARG PHP_VERSION
+FROM ${ENV_SOURCE_IMAGE}:${PHP_VERSION} AS spx-builder
+
+USER root
+RUN dnf install -y php-devel \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+RUN set -eux \
+    && cd /tmp \
+    && git clone https://github.com/NoiseByNorthwest/php-spx.git \
+    && cd php-spx \
+    && phpize \
+    && ./configure \
+    && make \
+    && sudo make install
+
+FROM ${ENV_SOURCE_IMAGE}:${PHP_VERSION}
+COPY --from=spx-builder /usr/lib64/php/modules/spx.so /usr/lib64/php/modules/spx.so
+COPY --from=spx-builder /usr/share/misc/php-spx /usr/share/misc/php-spx
+COPY spx.ini /etc/php.d/30-spx.ini
+
+ENV SPX_ENABLED=1
+USER www-data

--- a/php-fpm/spx/spx.ini
+++ b/php-fpm/spx/spx.ini
@@ -4,7 +4,6 @@ extension=spx.so
 spx.debug=1
 spx.http_enabled=1
 spx.http_key=warden
-; spx.http_ip_var=X_FORWARDED_FOR
 spx.http_ip_whitelist="*"
 spx.http_profiling_enabled=1
 spx.http_profiling_auto_start=1

--- a/php-fpm/spx/spx.ini
+++ b/php-fpm/spx/spx.ini
@@ -1,0 +1,14 @@
+extension=spx.so
+
+[spx]
+spx.debug=1
+spx.http_enabled=1
+spx.http_key=warden
+; spx.http_ip_var=X_FORWARDED_FOR
+spx.http_ip_whitelist="*"
+spx.http_profiling_enabled=1
+spx.http_profiling_auto_start=1
+spx.http_trusted_proxies=REMOTE_ADDR
+
+[zlib]
+zlib.output_compression = 0

--- a/varnish/default.vcl
+++ b/varnish/default.vcl
@@ -55,6 +55,11 @@ sub vcl_recv {
         }
     }
 
+    # Do not handle requests going through SPX
+    if (req.http.Cookie ~ "SPX_ENABLED" || req.http.Cookie ~ "SPX_KEY" || req.url ~ "(?i)(\?|\&)SPX_UI_URI=" || req.url ~ "(?i)(\?|\&)SPX_KEY=") {
+        return (pass);
+    }
+
     # We only deal with GET and HEAD by default
     if (req.method != "GET" && req.method != "HEAD") {
         return (pass);


### PR DESCRIPTION
Adds a new SPX image build. Adjusts Nginx configuration to route requests to the SPX container (similar to Xdebug), and prevents Varnish from caching SPX requests.