### PR TITLE
Add Openswoole extension

### DIFF
--- a/php/cli/Dockerfile
+++ b/php/cli/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/centos/centos:stream9
 
 ARG PHP_VERSION
 ARG PHP_EXTENSIONS="bcmath cli common gd gmp intl json mbstring \
-    mcrypt sodium mysqlnd pgsql opcache pdo pdo_pgdql pecl-msgpack pecl-amqp pecl-redis pecl-imagick pecl-zip process soap xml xmlrpc"
+    mcrypt sodium mysqlnd pgsql opcache pdo pdo_pgdql pecl-msgpack pecl-amqp pecl-redis pecl-imagick pecl-zip pecl-openswoole process soap xml xmlrpc"
 
 RUN dnf update -y \
     && dnf clean all \


### PR DESCRIPTION
Adds the Openswoole PECL extension to base PHP image. The extension is available for all versions of PHP we build. This is the first step in being able to utilize the Magento 2.4.7 application server.

No new docker entrypoint is configured because that is actually application dependent. Magento's openswoole entrypoint is going to be different than a Laravel one. So this should be handled in the warden environment itself.

```
sh-5.1# dnf search pecl-openswoole
Extra Packages for Enterprise Linux 9 - aarch64                                  5.5 MB/s |  20 MB     00:03
Extra Packages for Enterprise Linux 9 openh264 (From Cisco) - aarch64            1.5 kB/s | 2.5 kB     00:01
Extra Packages for Enterprise Linux 9 - Next - aarch64                           163 kB/s | 1.4 MB     00:08
Remi's Modular repository for Enterprise Linux 9 - aarch64                       229 kB/s | 573 kB     00:02
Safe Remi's RPM repository for Enterprise Linux 9 - aarch64                      390 kB/s | 833 kB     00:02
==================================== Name & Summary Matched: pecl-openswoole ====================================
php74-php-pecl-openswoole22-devel.aarch64 : php74-php-pecl-openswoole22 developer files (header)
php80-php-pecl-openswoole22-devel.aarch64 : php80-php-pecl-openswoole22 developer files (header)
php81-php-pecl-openswoole22-devel.aarch64 : php81-php-pecl-openswoole22 developer files (header)
php82-php-pecl-openswoole22-devel.aarch64 : php82-php-pecl-openswoole22 developer files (header)
php83-php-pecl-openswoole22-devel.aarch64 : php83-php-pecl-openswoole22 developer files (header)
========================================= Name Matched: pecl-openswoole =========================================
php74-php-pecl-openswoole22.aarch64 : High Performance Programmatic Server for PHP with Async IO, Coroutines and
                                    : Fibers
php80-php-pecl-openswoole22.aarch64 : High Performance Programmatic Server for PHP with Async IO, Coroutines and
                                    : Fibers
php81-php-pecl-openswoole22.aarch64 : High Performance Programmatic Server for PHP with Async IO, Coroutines and
                                    : Fibers
php82-php-pecl-openswoole22.aarch64 : High Performance Programmatic Server for PHP with Async IO, Coroutines and
                                    : Fibers
php83-php-pecl-openswoole22.aarch64 : High Performance Programmatic Server for PHP with Async IO, Coroutines and
                                    : Fibers
```