### PR TITLE
Feature: Add WordPress specific images

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -163,3 +163,46 @@ jobs:
           PHP_VARIANT: ${{ matrix.php_variant }}
           INDEV_FLAG: ${{ github.ref == 'refs/heads/main' && '0' || '1' }}
         run: bash scripts/build.sh "${BUILD_GROUP}"
+
+  wordpress:
+    name: Build Warden PHP-FPM Images ${{ matrix.php_version }} (wordpress)
+    runs-on: ubuntu-latest
+    needs: php-fpm
+    strategy:
+      matrix:
+        php_version: ["7.4", "8.0", "8.1", "8.2", "8.3"]
+        php_variant: ["fpm-loaders"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build & Push Images
+        env:
+          BUILD_GROUP: php-fpm/wordpress
+          PRE_AUTH: 1
+          WARDEN_IMAGE_REPOSITORY: ghcr.io/wardenenv
+          PHP_SOURCE_IMAGE: ghcr.io/wardenenv/centos-php
+          PUSH_FLAG: 1
+          PHP_VERSION: ${{ matrix.php_version }}
+          PHP_VARIANT: ${{ matrix.php_variant }}
+          INDEV_FLAG: ${{ github.ref == 'refs/heads/main' && '0' || '1' }}
+        run: bash scripts/build.sh "${BUILD_GROUP}"
+      - uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Build & Push Images (Docker Hub)
+        env:
+          BUILD_GROUP: php-fpm/wordpress
+          PRE_AUTH: 1
+          PHP_SOURCE_IMAGE: ghcr.io/wardenenv/centos-php
+          PUSH_FLAG: 1
+          PHP_VERSION: ${{ matrix.php_version }}
+          PHP_VARIANT: ${{ matrix.php_variant }}
+          INDEV_FLAG: ${{ github.ref == 'refs/heads/main' && '0' || '1' }}
+        run: bash scripts/build.sh "${BUILD_GROUP}"

--- a/php-fpm/wordpress/Dockerfile
+++ b/php-fpm/wordpress/Dockerfile
@@ -1,0 +1,22 @@
+ARG ENV_SOURCE_IMAGE
+ARG PHP_VERSION
+FROM ${ENV_SOURCE_IMAGE}:${PHP_VERSION}
+USER root
+
+RUN npm install -g grunt-cli gulp yarn
+
+RUN set -eux \
+    && PHP_VERSION=$(php -v | head -n1 | cut -d' ' -f2 | awk -F '.' '{print $1$2}') \
+    && mkdir -p /usr/local/bin \
+    && curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar /usr/local/bin/wp-cli \
+    && chmod +x /usr/local/bin/wp-cli
+
+RUN set -eux \
+    && PHP_VERSION=$(php -v | head -n1 | cut -d' ' -f2 | awk -F '.' '{print $1$2}') \
+    && curl -o /etc/bash_completion.d/wp-completion.bash \
+        https://raw.githubusercontent.com/wp-cli/wp-cli/v2.10.0/utils/wp-completion.bash
+
+# Create wp alias for wp-cli
+RUN ln -s /usr/local/bin/wp-cli /usr/local/bin/wp
+
+USER www-data

--- a/php-fpm/wordpress/blackfire/Dockerfile
+++ b/php-fpm/wordpress/blackfire/Dockerfile
@@ -1,0 +1,20 @@
+ARG ENV_SOURCE_IMAGE
+ARG PHP_VERSION
+FROM ${ENV_SOURCE_IMAGE}:${PHP_VERSION}-magento2
+USER root
+
+RUN curl -o - "http://packages.blackfire.io/fedora/blackfire.repo" \
+    | sudo tee /etc/yum.repos.d/blackfire.repo \
+    && dnf install -y blackfire-php \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+    
+# Install the Blackfire Client to provide access to the CLI tool
+RUN mkdir -p /tmp/blackfire \
+    && curl -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
+    && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
+    && rm -rf /tmp/blackfire
+
+COPY blackfire/etc/php.d/*.ini /etc/php.d/
+
+USER www-data

--- a/php-fpm/wordpress/debug/Dockerfile
+++ b/php-fpm/wordpress/debug/Dockerfile
@@ -1,0 +1,14 @@
+ARG ENV_SOURCE_IMAGE
+ARG PHP_VERSION
+FROM ${ENV_SOURCE_IMAGE}:${PHP_VERSION}-wordpress
+USER root
+
+RUN set -eux \
+    && dnf install -y php-pecl-xdebug \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+COPY debug/etc/*.ini /etc/
+COPY debug/etc/php.d/*.ini /etc/php.d/
+
+USER www-data

--- a/php-fpm/wordpress/xdebug3/Dockerfile
+++ b/php-fpm/wordpress/xdebug3/Dockerfile
@@ -1,0 +1,19 @@
+ARG ENV_SOURCE_IMAGE
+ARG PHP_VERSION
+FROM ${ENV_SOURCE_IMAGE}:${PHP_VERSION}-wordpress
+ARG PHP_VERSION
+USER root
+
+RUN set -eux \
+    && dnf install -y php-pecl-xdebug3 \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+
+COPY xdebug3/etc/*.ini /etc/
+COPY xdebug3/etc/php.d/* /etc/php.d/
+
+RUN if [[ $(printf "8.0\n${PHP_VERSION}" | sort -h | head -n1) == "8.0" ]]; \
+    then mv /etc/php.d/15-xdebug3.2.ini.template /etc/php.d/15-xdebug.ini; \
+    else mv /etc/php.d/15-xdebug3.ini.template /etc/php.d/15-xdebug.ini; fi
+
+USER www-data


### PR DESCRIPTION
My biggest pet peeve with Warden is that Composer projects don't have [WP CLI](https://wp-cli.org/) available, similar to Magerun for Magento. This PR tries to solve it by adding images for WordPress.