### PR TITLE
Fix php image builds

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,6 +13,27 @@ on:
       - php-fpm/**
       - scripts/build.sh
 jobs:
+  legacy-php:
+    name: Build PHP Images
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build & Push Images
+        env:
+          PRE_AUTH: 1
+          IMAGE_NAME: ghcr.io/wardenenv/centos-php
+          VERSION_LIST: 7.4 8.0
+          VARIANT_LIST: cli cli-loaders fpm fpm-loaders
+          PUSH_FLAG: 1
+          INDEV_FLAG: ${{ github.ref == 'refs/heads/main' && '0' || '1' }}
+        run: bash php/scripts/build.sh
   php:
     name: Build PHP Images
     runs-on: ubuntu-latest
@@ -29,7 +50,7 @@ jobs:
         env:
           PRE_AUTH: 1
           IMAGE_NAME: ghcr.io/wardenenv/centos-php
-          VERSION_LIST: 7.4 8.0 8.1 8.2 8.3
+          VERSION_LIST: 8.1 8.2 8.3
           VARIANT_LIST: cli cli-loaders fpm fpm-loaders
           PUSH_FLAG: 1
           INDEV_FLAG: ${{ github.ref == 'refs/heads/main' && '0' || '1' }}
@@ -38,7 +59,7 @@ jobs:
   php-fpm:
     name: Build Warden PHP-FPM Images ${{ matrix.php_version }}
     runs-on: ubuntu-latest
-    needs: php
+    needs: [php, legacy-php]
     strategy:
       matrix:
         php_version: ["7.4", "8.0", "8.1", "8.2", "8.3"]

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,7 +14,7 @@ on:
       - scripts/build.sh
 jobs:
   legacy-php:
-    name: Build PHP Images
+    name: Build Legacy PHP Images
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
@navarr I tried to move the 7.4 and 8.0 images to a "legacy" job (and 8.1 can move there in December). Doing it this way will spawn 2 jobs running concurrently. From running in my repository it spent about 15 minutes building before trying to push and failing (because of missing / invalid credentials).