### PR TITLE
Add OpenSearch 2.12

### DIFF
--- a/.github/workflows/opensearch.yml
+++ b/.github/workflows/opensearch.yml
@@ -32,6 +32,7 @@ jobs:
           - "2.9"
           - "2.10"
           - "2.11"
+          - "2.12"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Magento 2.4.7 required OpenSearch 2.12, so we should build this one as well. See https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements.