### PR TITLE
Add Varnish 7.5

### DIFF
--- a/.github/workflows/varnish.yml
+++ b/.github/workflows/varnish.yml
@@ -23,6 +23,7 @@ jobs:
           - "7.2"
           - "7.3"
           - "7.4"
+          - "7.5"
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Magento 2.4.7 required Varnish 7.5, so we should build this one as well. See https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements.