### PR TITLE
PHP extension PECL swoole

### DIFF
--- a/php/cli/Dockerfile
+++ b/php/cli/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/centos/centos:stream9
 
 ARG PHP_VERSION
 ARG PHP_EXTENSIONS="bcmath cli common gd gmp intl json mbstring \
-    mcrypt sodium mysqlnd pgsql opcache pdo pdo_pgsql pecl-msgpack pecl-amqp pecl-redis pecl-imagick pecl-zip pecl-openswoole process soap xml xmlrpc"
+    mcrypt sodium mysqlnd pgsql opcache pdo pdo_pgsql pecl-msgpack pecl-amqp pecl-redis pecl-imagick pecl-zip pecl-swoole process soap xml xmlrpc"
 
 RUN dnf update -y \
     && dnf clean all \


### PR DESCRIPTION
@navarr 

Adobe Commerce Cloud uses PHP extension swoole, not openswoole

https://experienceleague.adobe.com/en/docs/commerce-operations/performance-best-practices/concepts/application-server

https://developer.adobe.com/commerce/php/development/components/app-server/

---

https://github.com/AdobeDocs/commerce-operations.en/pull/126

https://github.com/AdobeDocs/commerce-operations.en/pull/126

---

https://github.com/markshust/docker-magento/blob/83d238aa7cb843edd1b4e01c361e1e285487fdfc/images/php/8.3/Dockerfile#L46