### PR TITLE
Fix docker username to be secret

### DIFF
--- a/.github/workflows/magento1.yml
+++ b/.github/workflows/magento1.yml
@@ -27,9 +27,6 @@ on:
       push2dockerhub:
         required: true
         type: boolean
-      dockerhub_username:
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       environment:
@@ -67,11 +64,9 @@ on:
         required: true
         type: boolean
         default: true
-      dockerhub_username:
-        description: Docker Hub Username
-        required: true
-        type: string
-        default: "wardenenv"
+
+env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME || 'wardenenv' }}
 
 jobs:
   build:
@@ -107,8 +102,8 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build
         env:
           BUILD_GROUP: ${{ matrix.build_group }}
@@ -160,8 +155,8 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Create manifest list ${{ inputs.php_version }}
         uses: ./.github/actions/push-manifest
         with:
@@ -206,8 +201,8 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build
         env:
           BUILD_GROUP: ${{ matrix.build_group }}
@@ -264,8 +259,8 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Create manifest list ${{ inputs.php_version }}
         uses: ./.github/actions/push-manifest
         with:

--- a/.github/workflows/magento2.yml
+++ b/.github/workflows/magento2.yml
@@ -27,9 +27,6 @@ on:
       push2dockerhub:
         required: true
         type: boolean
-      dockerhub_username:
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       environment:
@@ -67,11 +64,9 @@ on:
         required: true
         type: boolean
         default: true
-      dockerhub_username:
-        description: Docker Hub Username
-        required: true
-        type: string
-        default: "wardenenv"
+
+env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME || 'wardenenv' }}
 
 jobs:
   build:
@@ -107,8 +102,8 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build
         env:
           BUILD_GROUP: ${{ matrix.build_group }}
@@ -160,8 +155,8 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Create manifest list ${{ inputs.php_version }}
         uses: ./.github/actions/push-manifest
         with:
@@ -206,8 +201,8 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build
         env:
           BUILD_GROUP: ${{ matrix.build_group }}
@@ -264,8 +259,8 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Create manifest list ${{ inputs.php_version }}
         uses: ./.github/actions/push-manifest
         with:

--- a/.github/workflows/orocommerce.yml
+++ b/.github/workflows/orocommerce.yml
@@ -27,9 +27,6 @@ on:
       push2dockerhub:
         required: true
         type: boolean
-      dockerhub_username:
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       environment:
@@ -67,11 +64,9 @@ on:
         required: true
         type: boolean
         default: true
-      dockerhub_username:
-        description: Docker Hub Username
-        required: true
-        type: string
-        default: "wardenenv"
+
+env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME || 'wardenenv' }}
 
 jobs:
   build:
@@ -107,8 +102,8 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build
         env:
           BUILD_GROUP: ${{ matrix.build_group }}
@@ -160,8 +155,8 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Create manifest list ${{ inputs.php_version }}
         uses: ./.github/actions/push-manifest
         with:
@@ -206,8 +201,8 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build
         env:
           BUILD_GROUP: ${{ matrix.build_group }}
@@ -264,8 +259,8 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Create manifest list ${{ inputs.php_version }}
         uses: ./.github/actions/push-manifest
         with:

--- a/.github/workflows/php-fpm.yml
+++ b/.github/workflows/php-fpm.yml
@@ -27,9 +27,6 @@ on:
       push2dockerhub:
         required: true
         type: boolean
-      dockerhub_username:
-        required: true
-        type: string
   workflow_dispatch:
     inputs:
       environment:
@@ -67,11 +64,9 @@ on:
         required: true
         type: boolean
         default: true
-      dockerhub_username:
-        description: Docker Hub Username
-        required: true
-        type: string
-        default: "wardenenv"
+
+env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKER_USERNAME || 'wardenenv' }}
 
 jobs:
   build:
@@ -107,7 +102,7 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.dockerhub_username }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build
         env:
@@ -159,7 +154,7 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.dockerhub_username }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Create manifest list ${{ inputs.php_version }}
         uses: ./.github/actions/push-manifest
@@ -204,7 +199,7 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.dockerhub_username }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Build
         env:
@@ -258,7 +253,7 @@ jobs:
       - uses: docker/login-action@v3
         if: inputs.push2dockerhub
         with:
-          username: ${{ inputs.dockerhub_username }}
+          username: ${{ env.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Create manifest list ${{ inputs.php_version }}
         uses: ./.github/actions/push-manifest

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -17,10 +17,13 @@ on:
       - main
       - develop
     paths:
-      - php/**
       - .github/workflows/php.yml
+      - .github/workflows/php-fpm.yml
+      - .github/workflows/magento1.yml
+      - .github/workflows/magento2.yml
+      - .github/workflows/orocommerce.yml
+      - php/**
       - php-fpm/**
-      - scripts/build.sh
 
 env:
   IMAGE_AUTHORS: ${{ vars.IMAGE_AUTHORS || 'wardenenv' }}
@@ -418,7 +421,6 @@ jobs:
       php_source_image: ${{ needs.define-variables.outputs.php_source_image }}
       image_authors: ${{ needs.define-variables.outputs.image_authors }}
       push2dockerhub: ${{ needs.define-variables.outputs.push2dockerhub == 'true' }}
-      dockerhub_username: ${{ needs.define-variables.outputs.dockerhub_username }}
       warden_image_repository: ${{ needs.define-variables.outputs.warden_image_repository }}
 
   magento1:
@@ -440,7 +442,6 @@ jobs:
       php_source_image: ${{ needs.define-variables.outputs.php_source_image }}
       image_authors: ${{ needs.define-variables.outputs.image_authors }}
       push2dockerhub: ${{ needs.define-variables.outputs.push2dockerhub == 'true' }}
-      dockerhub_username: ${{ needs.define-variables.outputs.dockerhub_username }}
       warden_image_repository: ${{ needs.define-variables.outputs.warden_image_repository }}
 
   magento2:
@@ -462,7 +463,6 @@ jobs:
       php_source_image: ${{ needs.define-variables.outputs.php_source_image }}
       image_authors: ${{ needs.define-variables.outputs.image_authors }}
       push2dockerhub: ${{ needs.define-variables.outputs.push2dockerhub == 'true' }}
-      dockerhub_username: ${{ needs.define-variables.outputs.dockerhub_username }}
       warden_image_repository: ${{ needs.define-variables.outputs.warden_image_repository }}
 
   orocommerce:
@@ -488,5 +488,4 @@ jobs:
       php_source_image: ${{ needs.define-variables.outputs.php_source_image }}
       image_authors: ${{ needs.define-variables.outputs.image_authors }}
       push2dockerhub: ${{ needs.define-variables.outputs.push2dockerhub == 'true' }}
-      dockerhub_username: ${{ needs.define-variables.outputs.dockerhub_username }}
       warden_image_repository: ${{ needs.define-variables.outputs.warden_image_repository }}


### PR DESCRIPTION
@navarr  This fixes the failing build process so dockerhub username is appropriately used in reusable workflows. The issue is that the repository has the username as a secret, and secrets aren't available to be passed as variables in GitHub actions. So this changes the scope `secrets` when referencing the username. I also updated the reusable workflows to use the appropriate dockerhub password variable name as well.