### PR TITLE
Add -compat packages to allow compatibility with 10.x releases.

### DIFF
--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,2 +1,12 @@
 ARG MARIADB_VERSION
-FROM mariadb:${MARIADB_VERSION}
+FROM mariadb:${MARIADB_VERSION:-lts}
+
+SHELL [ "/usr/bin/bash", "-c" ]
+
+RUN <<EOF
+    if [[ ${MARIADB_VERSION} =~ ^1:11 ]]; then
+        apt-get update
+        apt-get install -y mariadb-server-compat mariadb-client-compat
+        rm -rf /var/lib/apt/lists/*
+    fi
+EOF


### PR DESCRIPTION
This fixes https://github.com/wardenenv/warden/issues/864.

This is actually related to a change in the mariadb 11.x series: https://jira.mariadb.org/browse/MDEV-30203. 

This should be considered a short term fix, a longer term DB distribution cleanup (I believe this was discussed somewhere) should make it into warden to fix this bifurcated naming issue.


