### PR TITLE
Update to use the default path to bash for the env.

### DIFF
--- a/mariadb/Dockerfile
+++ b/mariadb/Dockerfile
@@ -1,7 +1,7 @@
 ARG MARIADB_VERSION
 FROM mariadb:${MARIADB_VERSION:-lts}
 
-SHELL [ "/usr/bin/bash", "-c" ]
+SHELL [ "/usr/bin/env", "bash", "-c" ]
 
 RUN <<EOF
     if [[ ${MARIADB_VERSION} =~ ^1:11 ]]; then


### PR DESCRIPTION
This will fix the early 10.x releases breaking in the build due to hard coded bash path.