### PR TITLE
Disable incompatible modules in Xdebug images.

### DIFF
--- a/php-fpm/xdebug3/context/etc/php.d/01-ioncube-loader.ini
+++ b/php-fpm/xdebug3/context/etc/php.d/01-ioncube-loader.ini
@@ -1,0 +1,1 @@
+; zend_extension=ioncube_loader.so

--- a/php-fpm/xdebug3/context/etc/php.d/10-opcache.ini
+++ b/php-fpm/xdebug3/context/etc/php.d/10-opcache.ini
@@ -1,2 +1,0 @@
-; Enable opcache extension module
-; zend_extension=opcache.so

--- a/php-fpm/xdebug3/context/etc/php.d/10-opcache.ini
+++ b/php-fpm/xdebug3/context/etc/php.d/10-opcache.ini
@@ -1,0 +1,2 @@
+; Enable opcache extension module
+; zend_extension=opcache.so

--- a/php-fpm/xdebug3/context/etc/php.d/15-sourceguardian.ini
+++ b/php-fpm/xdebug3/context/etc/php.d/15-sourceguardian.ini
@@ -1,0 +1,1 @@
+; extension=sourceguardian.so


### PR DESCRIPTION
Hopefully this will resolve many of the xdebug3 segfault issues. Given the build script, I believe this will work properly, but would love a second set of eyes @bap14.

Effectively this is the same as the following local override.

```
./.warden/warden-env.yml

services:
  php-debug:
    volumes:
      - ./.warden/php.d/01-ioncube-loader.ini:/etc/php.d/01-ioncube-loader.ini
      - ./.warden/php.d/10-opcache.ini:/etc/php.d/10-opcache.ini
      - ./.warden/php.d/15-sourceguardian.ini:/etc/php.d/15-sourceguardian.ini

./.warden/php.d/01-ioncube-loader.ini
; zend_extension=ioncube_loader.so; 

./.warden/php.d/10-opcache.ini:
; zend_extension=opcache.so

./.warden/php.d/15-sourceguardian.ini:
; extension=sourceguardian.so
```

