### PR TITLE
Add environment variable for nginx resolver to support easier AKS deployment

### DIFF
--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -13,6 +13,7 @@ ENV NGINX_UPSTREAM_BLACKFIRE_PORT 9000
 ENV NGINX_ROOT                    /var/www/html
 ENV NGINX_PUBLIC                  ''
 ENV NGINX_TEMPLATE                application.conf
+ENV NGINX_RESOLVER                127.0.0.1
 ENV XDEBUG_CONNECT_BACK_HOST      '""'
 
 COPY etc/nginx/fastcgi_params /etc/nginx/fastcgi_params.template
@@ -22,7 +23,7 @@ COPY etc/nginx/available.d/*.conf /etc/nginx/available.d/
 CMD envsubst '${NGINX_UPSTREAM_HOST} ${NGINX_UPSTREAM_PORT} \
               ${NGINX_UPSTREAM_BLACKFIRE_HOST} ${NGINX_UPSTREAM_BLACKFIRE_PORT} \
               ${NGINX_UPSTREAM_DEBUG_HOST} ${NGINX_UPSTREAM_DEBUG_PORT} \
-              ${NGINX_UPSTREAM_SPX_HOST} ${NGINX_UPSTREAM_SPX_PORT} \
+              ${NGINX_UPSTREAM_SPX_HOST} ${NGINX_UPSTREAM_SPX_PORT} ${NGINX_RESOLVER} \
               ${NGINX_ROOT} ${NGINX_PUBLIC} ${NGINX_TEMPLATE}' \
         < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf \
     && envsubst '${XDEBUG_CONNECT_BACK_HOST}' \

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -13,7 +13,7 @@ ENV NGINX_UPSTREAM_BLACKFIRE_PORT 9000
 ENV NGINX_ROOT                    /var/www/html
 ENV NGINX_PUBLIC                  ''
 ENV NGINX_TEMPLATE                application.conf
-ENV NGINX_RESOLVER                127.0.0.1
+ENV NGINX_RESOLVER                127.0.0.11
 ENV XDEBUG_CONNECT_BACK_HOST      '""'
 
 COPY etc/nginx/fastcgi_params /etc/nginx/fastcgi_params.template

--- a/nginx/etc/nginx/conf.d/default.conf
+++ b/nginx/etc/nginx/conf.d/default.conf
@@ -1,5 +1,5 @@
 # default Docker DNS server
-resolver 127.0.0.11;
+resolver ${NGINX_RESOLVER};
 
 # Select upstream backend to use based on presense of Xdebug cookies and Blackfire headers
 map "$http_X_BLACKFIRE_QUERY:$cookie_XDEBUG_SESSION$cookie_XDEBUG_PROFILE$cookie_XDEBUG_TRACE$arg_XDEBUG_SESSION$arg_XDEBUG_SESSION_START:$cookie_SPX_ENABLED$cookie_SPX_KEY$arg_SPX_ENABLED$arg_SPX_KEY$arg_SPX_UI_URI" $fastcgi_backend {


### PR DESCRIPTION
This pull request updates the way DNS resolver configuration is handled in the Nginx Docker setup. The main improvement is making the resolver address configurable via the `NGINX_RESOLVER` environment variable, which increases flexibility for different deployment environments.

**Configuration improvements:**

* Made the DNS resolver address in `default.conf` configurable by replacing the hardcoded value with the `${NGINX_RESOLVER}` environment variable.
* Added the `NGINX_RESOLVER` environment variable to the `nginx/Dockerfile` with a default value of `127.0.0.11`.
* Updated the `envsubst` command in `nginx/Dockerfile` to substitute the new `NGINX_RESOLVER` variable into the Nginx configuration template.