### PR TITLE
refactor(php-fpm): rework php-fpm backend selection to reduce complexity

### DIFF
--- a/nginx/etc/nginx/conf.d/default.conf
+++ b/nginx/etc/nginx/conf.d/default.conf
@@ -1,19 +1,17 @@
 # default Docker DNS server
 resolver 127.0.0.11;
 
-# Select upstream backend to use based on presense of Xdebug cookies and Blackfire headers
-map "$http_X_BLACKFIRE_QUERY:$cookie_XDEBUG_SESSION$cookie_XDEBUG_PROFILE$cookie_XDEBUG_TRACE$arg_XDEBUG_SESSION$arg_XDEBUG_SESSION_START:$cookie_SPX_ENABLED$cookie_SPX_KEY$arg_SPX_ENABLED$arg_SPX_KEY$arg_SPX_UI_URI" $fastcgi_backend {
-    # Nothing for debug and nothing for blackfire means its a pure request
-    "::" ${NGINX_UPSTREAM_HOST}:${NGINX_UPSTREAM_PORT};
-
-    # Use blackfire if the blackfire query is specified AND no debug cookie is set
-    "~::$" ${NGINX_UPSTREAM_BLACKFIRE_HOST}:${NGINX_UPSTREAM_BLACKFIRE_PORT};
-
-    # Use SPX if the SPX cookie is specified AND no xdebug cookie is set
-    "~::.+" ${NGINX_UPSTREAM_SPX_HOST}:${NGINX_UPSTREAM_SPX_PORT};
-
-    # In all other cases, a debug cookie will be present; use debug container
-    default ${NGINX_UPSTREAM_DEBUG_HOST}:${NGINX_UPSTREAM_DEBUG_PORT};
+# Select the appropriate FastCGI backend based on the presence of specific headers or cookies
+# Map Format: "<Service>:<Identifiers>;"
+map "
+BF:$http_X_BLACKFIRE_QUERY;
+DBG:$cookie_XDEBUG_SESSION$cookie_XDEBUG_PROFILE$cookie_XDEBUG_TRACE$arg_XDEBUG_SESSION$arg_XDEBUG_SESSION_START;
+SPX:$cookie_SPX_ENABLED$cookie_SPX_KEY$arg_SPX_ENABLED$arg_SPX_KEY$arg_SPX_UI_URI;
+" $fastcgi_backend {
+    "~DBG:.+;" ${NGINX_UPSTREAM_DEBUG_HOST}:${NGINX_UPSTREAM_DEBUG_PORT};
+    "~BF:.+;" ${NGINX_UPSTREAM_BLACKFIRE_HOST}:${NGINX_UPSTREAM_BLACKFIRE_PORT};
+    "~SPX:.+;" ${NGINX_UPSTREAM_SPX_HOST}:${NGINX_UPSTREAM_SPX_PORT};
+    default ${NGINX_UPSTREAM_HOST}:${NGINX_UPSTREAM_PORT};
 }
 
 server {
@@ -25,6 +23,8 @@ server {
     index index.html index.php;
     autoindex off;
     charset UTF-8;
+
+    add_header x-backend "$fastcgi_backend" always;
 
     include /etc/nginx/available.d/${NGINX_TEMPLATE};
     include /etc/nginx/default.d/*.conf;


### PR DESCRIPTION
> Note: Have not throughly tested it yet, mainly looking for feedback on the approach before investing the additional time.

Related PR within the docker compose repository - https://github.com/wardenenv/warden/pull/889

Rough concept PR for reworking the PHP fastcgi backend selection to hopefully resolve a few issues. 
Specially around the need to delete cookies when disabling debug containers to avoid 502 errors.

1. Add a debug header `x-backend` to improve the visibility of the backend selection
2. Rework the `fastcgi_backend` map to account for enabled status of each service/container to avoid 502 errors when disabling containers like SPX or XDEBUG
3. Rework the `fastcgi_backend` map to use named labels & multiple lines to improve maintainability

Should resolve the following issues:
https://github.com/wardenenv/warden/pull/820#issuecomment-2490627675
https://github.com/wardenenv/warden/issues/822

<img width="1728" height="604" alt="image" src="https://github.com/user-attachments/assets/c2d01a1f-fb3a-447c-baf7-b8fc858dccfb" />
