### PR TITLE
fix(php-spx): not respecting UI settings / enabled cookie

### DIFF
--- a/php-fpm/spx/context/spx.ini
+++ b/php-fpm/spx/context/spx.ini
@@ -5,8 +5,6 @@ spx.debug=1
 spx.http_enabled=1
 spx.http_key=warden
 spx.http_ip_whitelist="*"
-spx.http_profiling_enabled=1
-spx.http_profiling_auto_start=1
 spx.http_trusted_proxies=REMOTE_ADDR
 
 [zlib]


### PR DESCRIPTION
Fixes: https://github.com/wardenenv/warden/issues/822#issuecomment-3112327299

Currently SPX ignores the `SPX_ENABLED` cookie, and Enabled state within the Control Panel, and profiles every request even when disabled.

This PR resolves that, and only profiles requests when the Enabled Cookie / Control Panel state is set to Enabled.