### PR TITLE
fix(php): symfony/mailer unsupported sendmail command flags

### DIFF
--- a/php-fpm/_base/context/etc/php.d/05-additions.ini.template
+++ b/php-fpm/_base/context/etc/php.d/05-additions.ini.template
@@ -1,1 +1,1 @@
-sendmail_path = "/usr/local/bin/mhsendmail --smtp-addr='${MAILHOG_HOST}:${MAILHOG_PORT}'"
+sendmail_path = "/usr/local/bin/mhsendmail -t --smtp-addr='${MAILHOG_HOST}:${MAILHOG_PORT}'"


### PR DESCRIPTION
Fixes: https://github.com/wardenenv/warden/issues/869

Resolves sendmail errors on newer versions of PHP / Magento

The sendmail `-t` flag [does nothing](https://mailpit.axllent.org/docs/install/sendmail/#mailpits-sendmail-options), but allows us to satisfy the [check in symfony/mailer](https://github.com/symfony/mailer/blob/6.1/Transport/SendmailTransport.php#L58). 

This is the [same approach as taken by ddev](https://github.com/ddev/ddev/pull/5151).

---

I've ran this through the following tests:

#### Containers from Docker Hub
Magento | PHP | Errors
--- | --- | ---
2.4.4-p13 | 8.1 | No Errors
2.4.8-p3 | 8.3 | Error: `... must be one of "-bs" or "-t" ...`

#### Containers built from PR
Magento | PHP | Errors
--- | --- | ---
2.4.4-p13 | 8.1 | No Errors
2.4.8-p3 | 8.3 | No Errors
