### PR TITLE
enable ioncube loader for PHP 8.5 (fix image building)

### DIFF
--- a/.github/container-structure-tests/cli-loaders/8.5.yml
+++ b/.github/container-structure-tests/cli-loaders/8.5.yml
@@ -4,12 +4,12 @@ commandTests:
   - name: "ionCube Module Loaded"
     command: "php"
     args: ["-m"]
-    excludedOutput:
+    expectedOutput:
       - "(?m)^the ionCube PHP Loader"
   - name: "ionCube Configuration Check"
     command: "php"
     args: ["-i"]
-    excludedOutput:
+    expectedOutput:
       - "/etc/php\\.d/01-ioncube-loader.ini"
       - "(?m)^For Loader updates visit www\\.ioncube\\.com/loaders\\.php"
       - "(?m)^ioncube\\.loader\\.encoded_paths => no value => no value"
@@ -17,4 +17,4 @@ commandTests:
 fileExistenceTests:
   - name: "IonCube Config Exists"
     path: "/etc/php.d/01-ioncube-loader.ini"
-    shouldExist: false
+    shouldExist: true

--- a/.github/container-structure-tests/fpm-loaders/8.5.yml
+++ b/.github/container-structure-tests/fpm-loaders/8.5.yml
@@ -4,12 +4,12 @@ commandTests:
   - name: "ionCube Module Loaded"
     command: "php-fpm"
     args: ["-m"]
-    excludedOutput:
+    expectedOutput:
       - "(?m)^the ionCube PHP Loader"
   - name: "ionCube Configuration Check"
     command: "php-fpm"
     args: ["-i"]
-    excludedOutput:
+    expectedOutput:
       - "/etc/php\\.d/01-ioncube-loader.ini"
       - "(?m)^For Loader updates visit www\\.ioncube\\.com/loaders\\.php"
       - "(?m)^ioncube\\.loader\\.encoded_paths => no value => no value"
@@ -17,4 +17,4 @@ commandTests:
 fileExistenceTests:
   - name: "IonCube Config Exists"
     path: "/etc/php.d/01-ioncube-loader.ini"
-    shouldExist: false
+    shouldExist: true

--- a/.github/container-structure-tests/php-fpm/8.5.yml
+++ b/.github/container-structure-tests/php-fpm/8.5.yml
@@ -4,12 +4,12 @@ commandTests:
   - name: "ionCube Module Loaded"
     command: "php-fpm"
     args: ["-m"]
-    excludedOutput:
+    expectedOutput:
       - "(?m)^the ionCube PHP Loader"
   - name: "ionCube Configured"
     command: "php-fpm"
     args: ["-i"]
-    excludedOutput:
+    expectedOutput:
       - "/etc/php\\.d/01-ioncube-loader.ini"
       - "(?m)^For Loader updates visit www\\.ioncube\\.com/loaders\\.php"
       - "(?m)^ioncube\\.loader\\.encoded_paths => no value => no value"
@@ -17,4 +17,4 @@ commandTests:
 fileExistenceTests:
   - name: "IonCube Config Exists"
     path: "/etc/php.d/01-ioncube-loader.ini"
-    shouldExist: false
+    shouldExist: true


### PR DESCRIPTION
This fixes building the images for PHP, and it is especially relevant for this: [CVE-2026-40261](https://nvd.nist.gov/vuln/detail/CVE-2026-40261) and [CVE-2026-40176](https://nvd.nist.gov/vuln/detail/CVE-2026-40176)

ionCube has released support for PHP 8.5 in their 15.5.0 release:
"Loader 15.5.0 Release Including Loaders for PHP 8.5"

The CI was failing here: https://github.com/wardenenv/images/actions/runs/24623576735/job/71998732891#step:6:5455

I'd like to help test this out if needed.