### PR TITLE
Add MariaDB version 12.3 to workflow

### DIFF
--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -41,7 +41,7 @@ jobs:
           - "12.0"
           - "12.1"
           - "12.2"
-          - "12.3"
+          - "12.3-rc"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/mariadb.yml
+++ b/.github/workflows/mariadb.yml
@@ -41,6 +41,7 @@ jobs:
           - "12.0"
           - "12.1"
           - "12.2"
+          - "12.3"
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
Magento 2.4.9 now works with MariaDB 12.3 - see https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements